### PR TITLE
Potential fix for code scanning alert no. 111: disallow unused variables

### DIFF
--- a/src/main/services/ai-service.js
+++ b/src/main/services/ai-service.js
@@ -391,7 +391,7 @@ User message: ${message}`;
       return null;
     }
 
-    const path = this.extractFilePath(message, lowerMessage, 'read');
+    const path = this.extractFilePath(message, lowerMessage);
     if (!path) {
       return null;
     }
@@ -420,7 +420,7 @@ User message: ${message}`;
            lowerMessage.includes('show me the content');
   }
 
-  extractFilePath(message, lowerMessage, operation) {
+  extractFilePath(message, lowerMessage) {
     const explicitPathMatch = message.match(new RegExp(`${this.userHomePath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}[/\\w.-]*`, 'i'));
     if (explicitPathMatch) {
       return explicitPathMatch[0];


### PR DESCRIPTION
Potential fix for [https://github.com/djleamen/mai-buddy/security/code-scanning/111](https://github.com/djleamen/mai-buddy/security/code-scanning/111)

To fix this problem, the parameter `operation` should be removed from the function signature of `extractFilePath` since it is not used anywhere in the function body. This change should be made both where the function is defined and in any places where it is called. From the provided snippet, one call is seen at line 394: `const path = this.extractFilePath(message, lowerMessage, 'read');`. The third argument `'read'` should be removed, so the function is invoked with only `message` and `lowerMessage`. The only edits required are (1) update the function definition parameter list, and (2) update the corresponding function call(s) in this file to pass only the arguments that remain.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
