### PR TITLE
Declare marked and DOMPurify as ESLint globals

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -23,6 +23,8 @@ module.exports = {
     'module': 'readonly',
     'process': 'readonly',
     '__dirname': 'readonly',
-    'console': 'readonly'
+    'console': 'readonly',
+    'marked': 'readonly',
+    'DOMPurify': 'readonly'
   }
 };


### PR DESCRIPTION
## Testing summary

- Created `python/.venv` (matching the existing gitignore entry) with the light deps (anthropic, python-dotenv, requests); GUI deps (pywebview, pystray, pynput) skipped since the app window/tray cannot run headless.
- `py_compile` passes for all Python sources.
- Exercised the `Api` dispatcher and services directly (with `XDG_CONFIG_HOME` pointed at a scratch dir):
  - settings roundtrip with secret sanitisation — secrets never land in `settings.json`;
  - unknown IPC channel returns a structured error;
  - `send-message` without an API key returns the expected configuration error;
  - history store persists, filters malformed rows, and clears;
  - tool registry: 8 tools, type filtering, connection listing;
  - filesystem tool guards: writes outside `$HOME` and to protected paths (`/etc/...`) are refused; write/read roundtrip inside home works; missing-file read errors surface cleanly; `~` expansion works;
  - shell tool: non-zero exit codes captured, empty command rejected, timeout enforced (`sleep 5` with 1s timeout fails gracefully);
  - unknown tool names and bad parameters return error payloads instead of raising;
  - connection schemas never echo secret values back; `github` tester correctly reports a missing token; saving an empty secret preserves the existing value.
- `node --check` passes for all renderer JS.
- Not testable here: live Anthropic API calls (no key) and the pywebview/tray/hotkey GUI layer.

## Fixes

- ESLint (`eslint:recommended`, as run by the repo's ESLint workflow) failed with two `no-undef` errors in `renderer.js` for `marked` and `DOMPurify`. Both are loaded from CDN script tags in `index.html` and already used behind `typeof` guards, so they are now declared as readonly globals in `.eslintrc.js`. ESLint exits clean afterwards.

https://claude.ai/code/session_01Pdr2u5eE9XswikXHCjZNs5

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pdr2u5eE9XswikXHCjZNs5)_