### PR TITLE
fix(mcp-tools): sandbox read_file and list_directory to match write guard

### DIFF
--- a/python/services/mcp_tools.py
+++ b/python/services/mcp_tools.py
@@ -27,7 +27,7 @@ _PROTECTED_ROOTS = (
 def _expand(p: str) -> str:
     return os.path.expanduser(p) if p else p
 
-def _assert_safe_write_path(raw: str) -> Path:
+def _assert_safe_path(raw: str) -> Path:
     if not isinstance(raw, str) or not raw:
         raise ValueError("Invalid path")
     resolved = Path(_expand(raw)).resolve()
@@ -42,20 +42,25 @@ def _assert_safe_write_path(raw: str) -> Path:
         raise ValueError(f"Path is outside the user home directory: {s}")
     return resolved
 
+# Backwards-compatible alias; reads, writes and listings share one guard so the
+# AI-callable filesystem tools cannot escape the home sandbox in any direction.
+_assert_safe_write_path = _assert_safe_path
+
 def _read_file(path: str, encoding: str = "utf-8") -> Dict[str, Any]:
-    expanded = _expand(path)
-    with open(expanded, "r", encoding=encoding) as fh:
-        return {"content": fh.read(), "path": expanded}
+    safe = _assert_safe_path(path)
+    with open(safe, "r", encoding=encoding) as fh:
+        return {"content": fh.read(), "path": str(safe)}
 
 def _write_file(path: str, content: str, encoding: str = "utf-8") -> Dict[str, Any]:
-    safe = _assert_safe_write_path(path)
+    safe = _assert_safe_path(path)
     safe.parent.mkdir(parents=True, exist_ok=True)
     with open(safe, "w", encoding=encoding) as fh:
         fh.write(content or "")
     return {"path": str(safe), "bytes": len(content or "")}
 
 def _list_directory(path: str) -> Dict[str, Any]:
-    expanded = _expand(path)
+    safe = _assert_safe_path(path)
+    expanded = str(safe)
     entries = []
     for entry in sorted(os.listdir(expanded)):
         full = os.path.join(expanded, entry)


### PR DESCRIPTION
## Summary

The AI-callable filesystem tools in `python/services/mcp_tools.py` were asymmetric: `write_file` was sandboxed via `_assert_safe_write_path` (blocks `_PROTECTED_ROOTS`, resolves `~`/symlinks, rejects paths outside the user's home), but `read_file` and `list_directory` had **no path guard**. The model could therefore escape the home sandbox and read `/etc/passwd`, SSH keys, or other users' files.

This closes that read-side gap by routing reads, listings, and writes through a single shared guard.

## Changes

- Generalized `_assert_safe_write_path` into a shared `_assert_safe_path` (same protected-root list, same `expanduser`/`realpath` resolution, same `ValueError` convention). A `_assert_safe_write_path = _assert_safe_path` alias is kept for backwards compatibility.
- `_read_file` now calls `_assert_safe_path(path)` before opening the file and returns the resolved path.
- `_list_directory` now calls `_assert_safe_path(path)` before touching the filesystem.
- `_execute_command` / `shell=True` was intentionally left untouched (documented, by-design capability, out of scope).

## Testing

- `python -m py_compile python/services/mcp_tools.py` — passes.
- Throwaway script (removed after run) importing the module and asserting:
  - `_read_file` and `_list_directory` now **raise** `ValueError("Refusing to operate on protected path: ...")` for `/etc/passwd` and `/etc`.
  - Both still **succeed** for a temp file created inside the user's home (`~`).
  - Result: `ALL PASS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0193FofFePJp2CBnHfwMwXv9

---
_Generated by [Claude Code](https://claude.ai/code/session_0193FofFePJp2CBnHfwMwXv9)_