### PR TITLE
fix(mcp): repair MCP tool execution from the connections UI

### DIFF
--- a/src/renderer/renderer.js
+++ b/src/renderer/renderer.js
@@ -835,7 +835,7 @@ class MaiBuddyRenderer {
                           <pre class="tool-parameters">${this.escapeHtml(JSON.stringify(tool.parameters, null, 2))}</pre>
                         </details>
                       ` : ''}
-                      <button class="btn btn-sm" onclick="renderer.executeMCPTool('${connectionId}', '${tool.name}')">
+                      <button class="btn btn-sm" onclick="renderer.executeMCPTool('${tool.name}')">
                         Execute Tool
                       </button>
                     </div>
@@ -859,11 +859,11 @@ class MaiBuddyRenderer {
     }
   }
 
-  async executeMCPTool(connectionId, toolName) {
+  async executeMCPTool(toolName) {
     const parameters = {};
     
     if (toolName === 'list_directory') {
-      parameters.path = prompt('Enter directory path:', process.cwd() || '/');
+      parameters.path = prompt('Enter directory path:', '~');
       if (!parameters.path) return;
     } else if (toolName === 'execute_command') {
       parameters.command = prompt('Enter command to execute:', 'echo "Hello from MCP!"');
@@ -874,7 +874,7 @@ class MaiBuddyRenderer {
     }
 
     try {
-      const result = await ipcRenderer.invoke('mcp-execute-tool', connectionId, toolName, parameters);
+      const result = await ipcRenderer.invoke('mcp-execute-tool', toolName, parameters);
       
       if (result.success) {
         const modal = document.createElement('div');


### PR DESCRIPTION
## What

Two bugs in `src/renderer/renderer.js` made every **Execute Tool** click in the
MCP manager fail before it reached the backend.

### 1. IPC arity mismatch (tools never executed)

`executeMCPTool` invoked the channel with three positional args:

```js
ipcRenderer.invoke('mcp-execute-tool', connectionId, toolName, parameters);
```

but the Python handler takes two:

```python
def do_mcp_execute_tool(self, name, params=None): ...
```

The pywebview bridge forwards all extra args to `handler(*args)`, so the call
raised `TypeError`, was caught in `Api.invoke`, and returned
`{"success": False}`. Even if the arity had matched, `name` would have been
bound to `connectionId` rather than the tool name. Tools are registered
globally by name (`list_directory`, `execute_command`, `read_file`), so
`connectionId` isn't needed — this drops it (and the now-unused parameter) and
passes `(toolName, parameters)`.

### 2. `process.cwd()` throws in the renderer

The `list_directory` prompt defaulted to `process.cwd()`, but this renderer
runs under pywebview with no Node integration (it uses the `window.ipcRenderer`
shim). `process` is undefined there, so the line threw `ReferenceError` before
the prompt appeared. Defaults to `'~'`, which the Python side expands via
`os.path.expanduser` and accepts through `_assert_safe_path`.

## Testing

- `node --check src/renderer/renderer.js` passes.
- Traced the call path against `python/api.py` (`do_mcp_execute_tool`) and
  `python/services/mcp_tools.py` (`execute_tool`, `_assert_safe_path`,
  `_expand`) to confirm the new argument order and the `'~'` default resolve
  correctly. No test suite exists in the repo.

---
_Generated by [Claude Code](https://claude.ai/code/session_019JHX5RDsKZP48Wrp9iex8J)_