### PR TITLE
fix(renderer): render messages as plain text when DOMPurify is missing

### DIFF
--- a/src/renderer/renderer.js
+++ b/src/renderer/renderer.js
@@ -320,17 +320,17 @@ class MaiBuddyRenderer {
     const contentDiv = document.createElement('div');
     contentDiv.className = 'message-content';
     if (isError) contentDiv.style.borderColor = 'var(--error-color)';
-    if (role === 'assistant' && !isError && typeof marked !== 'undefined') {
+    if (role === 'assistant' && !isError && typeof marked !== 'undefined' && typeof DOMPurify !== 'undefined') {
       try {
         const html = marked.parse(content, { gfm: true, breaks: true });
-        contentDiv.innerHTML = (typeof DOMPurify !== 'undefined')
-          ? DOMPurify.sanitize(html)
-          : html;
+        contentDiv.innerHTML = DOMPurify.sanitize(html);
         contentDiv.classList.add('markdown');
       } catch (_) {
         contentDiv.textContent = content;
       }
     } else {
+      // No sanitizer available (or plain/error message): render as plain text
+      // rather than injecting unsanitized model-generated HTML.
       contentDiv.textContent = content;
     }
     


### PR DESCRIPTION
## What changed

In `src/renderer/renderer.js`, `addMessage()` rendered assistant messages through `marked.parse()` and then assigned the result to `innerHTML`. When `DOMPurify` was undefined, it fell back to assigning the **raw, unsanitized** HTML:

```js
contentDiv.innerHTML = (typeof DOMPurify !== 'undefined')
  ? DOMPurify.sanitize(html)
  : html;   // <-- raw model-generated HTML
```

Now the HTML path is only taken when `DOMPurify` is actually loaded; if the sanitizer is unavailable (e.g. the bundled `vendor/purify.min.js` fails to load), the message is rendered as plain text via `textContent` instead of injecting model-generated markup.

## Why

Defense in depth. The app's CSP (`script-src 'self'`) already blocks inline `<script>`, but non-script HTML-injection vectors remain, and relying on a vendored script always being present is fragile. Failing closed to plain text removes that risk with no downside — sanitized markdown still renders normally when DOMPurify is present.

## Testing

- `node --check src/renderer/renderer.js` — syntax OK.
- Logic review: the `marked` + `DOMPurify` present path is unchanged; the new guard only diverts the previously-raw-HTML fallback to the existing plain-text branch.

## Scope

Single-function change; no behavior change when DOMPurify is loaded (the normal case).

---
_Generated by [Claude Code](https://claude.ai/code/session_01DYuUvWVRhGCC5ECYGwb32i)_