### PR TITLE
fix(ai): revert to default system prompt when custom prompt is cleared

### DIFF
--- a/python/services/ai_service.py
+++ b/python/services/ai_service.py
@@ -91,8 +91,10 @@ class AIService:
             settings.get("aiModel") or settings.get("model") or DEFAULT_MODEL
         )
         custom_prompt = (settings.get("systemPrompt") or "").strip()
-        if custom_prompt:
-            self._system_prompt = custom_prompt
+        # Fall back to the default when the custom prompt is empty so that
+        # clearing systemPrompt in settings reverts a long-lived instance
+        # instead of leaving a stale custom prompt active for the session.
+        self._system_prompt = custom_prompt or DEFAULT_SYSTEM_PROMPT
         api_key = store.get_api_key()
         self._client = Anthropic(api_key=api_key) if api_key else None
 


### PR DESCRIPTION
## Summary

`AIService` is a long-lived instance (created once in `Api.__init__`), and `do_save_settings` calls `reload()`. But `reload()` only overwrote `self._system_prompt` when the custom `systemPrompt` setting was truthy:

```python
custom_prompt = (settings.get("systemPrompt") or "").strip()
if custom_prompt:
    self._system_prompt = custom_prompt
```

So once a user set a custom system prompt and then **cleared** it and saved, the stale custom prompt stayed active for the rest of the session instead of falling back to `DEFAULT_SYSTEM_PROMPT`.

## Fix

Always assign `self._system_prompt`, defaulting to `DEFAULT_SYSTEM_PROMPT` when the setting is empty:

```python
self._system_prompt = custom_prompt or DEFAULT_SYSTEM_PROMPT
```

## Testing
`python -m py_compile python/services/ai_service.py` passes. The change is a one-line behavioral fix in a pure settings-load path (no test infrastructure exists in the repo to extend).

---
_Generated by [Claude Code](https://claude.ai/code/session_01RfqQPWkTooa6Hp62mnU518)_